### PR TITLE
OS X does not define all open-time flags.

### DIFF
--- a/src/mw-newlib.cpp
+++ b/src/mw-newlib.cpp
@@ -29,6 +29,13 @@ using namespace mw::debug;
 #define flag(Name) _##Name
 #endif
 
+#if defined (BOOST_OS_MACOS)
+// These flags don't exist on OS X
+#define O_DIRECT 0
+#define O_LARGEFILE 0
+#define O_NOATIME 0
+#define O_PATH 0
+#endif
 
 struct open_flags
 {


### PR DESCRIPTION
This patch just makes the code compile, since OS X doesn't define these flags.
OS X implements some of these flags using a different mechanisms, so this would have to be added later if required. 

cc @timonwalther @klemens-morgenstern 